### PR TITLE
Code to check the number of max_lambda to the size of transaction was revised.

### DIFF
--- a/lamp.py
+++ b/lamp.py
@@ -362,7 +362,7 @@ def maxLambda(transaction_list):
 
 	# check the max lambda to the nuber of transactions
 	if max_value > ( len(transaction_list)/2 ):
-		max_value = len(transaction_list)/2
+		max_value = int( len(transaction_list)/2 )
 	
 	return max_value
 

--- a/lamp.py
+++ b/lamp.py
@@ -354,8 +354,8 @@ def maxLambda(transaction_list):
 			max_value = i
 
 	# check the max lambda to the nuber of transactions
-	if max_value > ( len(transaction_list)/2 ):
-		max_value = len(transaction_list)/2
+	if max_value > ( len(transaction_list)):
+		max_value = len(transaction_list)
 	
 	return max_value
 


### PR DESCRIPTION
Dear Developers of LAMP,

Hi Hello.  I'm Takahiro Yamada in UCSD in USA.

There was an oddity in the calculation process of `max_lambda` that has been corrected.
The length of the transaction_list is the number of genes to target, and in the following code section (lamp.py, line 363 to 365), if extra TF-Gene relationships are mixed in the item file or the exp file, the `max_lambda` is intended to be modified with the total number of genes listed in the item file as the upper limit I believe.

```
# check the max lambda to the nuber of transactions
	if max_value > ( len(transaction_list)/2 ):
		max_value = len(transaction_list)/2
```

From this point of view, instead of setting `max_lambda` to one-half of the length of the transaction_list, I have modified it to assign the length of the transaction_list as it is (otherwise, if this condition is violated and the number of target genes is an odd number, an error will occur at line 60 of frequentPatterns.py).

I hope this code could improve LAMP.

Best.

Takahiro